### PR TITLE
fix a spelling typo in html/includes.erb

### DIFF
--- a/templates/default/header/html/includes.erb
+++ b/templates/default/header/html/includes.erb
@@ -1,1 +1,1 @@
-Included heaers
+Included headers


### PR DESCRIPTION
some background here https://github.com/Mav7/mruby.github.io/pull/1
