### PR TITLE
Added a version restriction to yard dependency

### DIFF
--- a/yard-mruby.gemspec
+++ b/yard-mruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "yard"
+  spec.add_dependency "yard", "< 0.9.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
There were two errors due to some breaking changes in yard 0.9.0.

Added a pessimistic version to the yard dependency in the gemspec to fix the current version. Will send another PR for the 0.9.0 fixes.