### PR TITLE
Update to Yard >= 0.9.0

### DIFF
--- a/lib/yard/mruby/code_objects/header_object.rb
+++ b/lib/yard/mruby/code_objects/header_object.rb
@@ -4,11 +4,11 @@ module YARD::MRuby::CodeObjects
   # It groups C Functions and define macros.
   class HeaderObject < YARD::CodeObjects::NamespaceObject
     def functions
-      children.find_all {|d| d.is_a?(FunctionObject) } 
+      children.find_all {|d| d.is_a?(FunctionObject) }
     end
 
     def defines
-      children.find_all {|d| d.is_a?(DefineObject) } 
+      children.find_all {|d| d.is_a?(DefineObject) }
     end
 
     def typedefs
@@ -16,7 +16,7 @@ module YARD::MRuby::CodeObjects
     end
 
     def path
-      self.name
+      self.name.to_s
     end
 
     def title

--- a/spec/code_objects/header_object_spec.rb
+++ b/spec/code_objects/header_object_spec.rb
@@ -1,0 +1,10 @@
+require_relative 'spec_helper'
+
+describe YARD::MRuby::CodeObjects::HeaderObject do
+  before { Registry.clear }
+
+  it "should return the name of the header for the path" do
+    header_object = YARD::MRuby::CodeObjects::HeaderObject.new(nil, :"mruby.h")
+    expect(header_object.path).to eq("mruby.h")
+  end
+end

--- a/spec/code_objects/spec_helper.rb
+++ b/spec/code_objects/spec_helper.rb
@@ -1,0 +1,1 @@
+require_relative '../spec_helper'

--- a/spec/handlers/c/source/class_handler_spec.rb
+++ b/spec/handlers/c/source/class_handler_spec.rb
@@ -8,7 +8,11 @@ describe YARD::MRuby::Handlers::C::Source::ClassHandler do
   end
 
   it "should register classes under namespaces" do
-    parse_init 'cFoo = mrb_define_class_under(mrb, cBar, "Foo", rb_cObject);'
+    parse_init(<<-eof)
+      cBar = mrb_define_class(mrb, "Bar", mrb->object_class);
+      cFoo = mrb_define_class_under(mrb, cBar, "Foo", rb_cObject);'
+    eof
+
     expect(Registry.at('Bar::Foo').type).to be :class
   end
 

--- a/spec/handlers/c/source/module_handler_spec.rb
+++ b/spec/handlers/c/source/module_handler_spec.rb
@@ -7,7 +7,11 @@ describe YARD::MRuby::Handlers::C::Source::ModuleHandler do
   end
 
   it "should register modules under namespaces" do
-    parse_init 'mFoo = mrb_define_module_under(mrb, mBar, "Foo");'
+    parse_init(<<-eof)
+      cBar = mrb_define_module(mrb,"Bar");
+      cFoo = mrb_define_module_under(mrb, cBar, "Foo");
+    eof
+
     expect(Registry.at('Bar::Foo').type).to be :module
   end
 

--- a/templates/default/fulldoc/html/setup.rb
+++ b/templates/default/fulldoc/html/setup.rb
@@ -51,7 +51,7 @@ end
 # This method removes the namespace from the root node, generates the class list,
 # and then adds it back into the root node.
 #
-def class_list(root = Registry.root)
+def class_list(root = Registry.root, tree = TreeContext.new)
   return super unless root == Registry.root
 
   include_namespace = YARD::MRuby::CodeObjects::HEADERS_ROOT

--- a/templates/default/fulldoc/html/setup.rb
+++ b/templates/default/fulldoc/html/setup.rb
@@ -56,7 +56,7 @@ def class_list(root = Registry.root, tree = TreeContext.new)
 
   include_namespace = YARD::MRuby::CodeObjects::HEADERS_ROOT
   root.instance_eval { children.delete include_namespace }
-  out = super(root)
+  out = super(root, tree)
   root.instance_eval { children.push include_namespace }
   out
 end

--- a/yard-mruby.gemspec
+++ b/yard-mruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "yard"
+  spec.add_dependency "yard", ">= 0.9.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
* Return a string from CodeObjects::HeaderObject#path

  A change in YARD::Serializers::FileSystemSerializer stopped
  calling `#to_s` on the the CodeObject passed, causing a NoMethodError
  for "+" missing Symbol (#path was just an alias to #name).

  Added minimal specs to cover only this case.

* Fixed some handler specs dealing with namespaces.

  A bug in the Yard c handler allowed namespacing to be determined
  without a proper parent RClass. See lsegal/yard#912

* There were some breaking changes to templates.